### PR TITLE
Fixed bug in mfp()

### DIFF
--- a/R/mfp.R
+++ b/R/mfp.R
@@ -253,12 +253,13 @@ if(length(tvars1)) {      # are some vars selected?
       tvars[iv] <- vars[-fp.pos][which(!is.na(tv))]
 	} 
     if(length(fp.pos)==0 & length(vars)) {
+      
       if(grepl("TRUE", tvars[iv])){ # if the variable is a factor (and therefore has TRUE added to the name) the match should take this into account. This avoids wrong matches for nested variable names, e.g. V2 and V20.
-        tv <- pmatch(paste0(vars, "TRUE"), tvars[iv])
+        tv <- sapply(vars, function(x) grepl(paste0("^", x, "TRUE"), tvars[iv]))
       } else{
-        tv <- pmatch(vars, tvars[iv])
+        tv <- sapply(vars, function(x) grepl(paste0("^", x, "$"), tvars[iv]))
       }
-      tvars[iv] <- vars[!is.na(tv)]
+      tvars[iv] <- vars[tv]
 	} 
   }
 }

--- a/R/mfp.R
+++ b/R/mfp.R
@@ -249,8 +249,13 @@ if(length(tvars1)) {      # are some vars selected?
     }
    } else {   # non-fp vars?
     if(length(vars[-fp.pos])) {
-      tv <- pmatch(vars[-fp.pos], tvars[iv])
-      tvars[iv] <- vars[-fp.pos][which(!is.na(tv))]
+      
+      if(grepl("TRUE", tvars[iv])){ # if the variable is a factor (and therefore has TRUE added to the name) the match should take this into account. This avoids wrong matches for nested variable names, e.g. V2 and V20.
+        tv <- sapply(vars[-fp.pos], function(x) grepl(paste0("^", x, "TRUE"), tvars[iv]))
+      } else{
+        tv <- sapply(vars[-fp.pos], function(x) grepl(paste0("^", x, "$"), tvars[iv]))
+      }
+      tvars[iv] <- vars[-fp.pos][tv]
 	} 
     if(length(fp.pos)==0 & length(vars)) {
       

--- a/R/mfp.R
+++ b/R/mfp.R
@@ -250,12 +250,9 @@ if(length(tvars1)) {      # are some vars selected?
    } else {   # non-fp vars?
     if(length(vars[-fp.pos])) {
       
-      if(grepl("TRUE", tvars[iv])){ # if the variable is a factor (and therefore has TRUE added to the name) the match should take this into account. This avoids wrong matches for nested variable names, e.g. V2 and V20.
-        tv <- sapply(vars[-fp.pos], function(x) grepl(paste0("^", x, "TRUE"), tvars[iv]))
-      } else{
-        tv <- sapply(vars[-fp.pos], function(x) grepl(paste0("^", x, "$"), tvars[iv]))
-      }
-      tvars[iv] <- vars[-fp.pos][tv]
+      tv <- sapply(vars[-fp.pos], function(x) grepl(paste0("^", x), tvars[iv]))
+      tvars[iv] <- unique(vars[-fp.pos][tv])
+      
 	} 
     if(length(fp.pos)==0 & length(vars)) {
       

--- a/R/mfp.R
+++ b/R/mfp.R
@@ -249,12 +249,16 @@ if(length(tvars1)) {      # are some vars selected?
     }
    } else {   # non-fp vars?
     if(length(vars[-fp.pos])) {
-	 tv <- pmatch(vars[-fp.pos], tvars[iv])
-     tvars[iv] <- vars[-fp.pos][which(!is.na(tv))]
+      tv <- pmatch(vars[-fp.pos], tvars[iv])
+      tvars[iv] <- vars[-fp.pos][which(!is.na(tv))]
 	} 
     if(length(fp.pos)==0 & length(vars)) {
-	 tv <- pmatch(vars, tvars[iv])
-     tvars[iv] <- vars[which(!is.na(tv))]
+      if(grepl("TRUE", tvars[iv])){ # if the variable is a factor (and therefore has TRUE added to the name) the match should take this into account. This avoids wrong matches for nested variable names, e.g. V2 and V20.
+        tv <- pmatch(paste0(vars, "TRUE"), tvars[iv])
+      } else{
+        tv <- pmatch(vars, tvars[iv])
+      }
+      tvars[iv] <- vars[!is.na(tv)]
 	} 
   }
 }


### PR DESCRIPTION
I fixed a bug where the glm summary did not show all variables in the mfp fit. This was due to a matching problem. When variable names are nested, e.g. "V2" and "V20", the match does not work as it should. in this case, both "V2" and "V20" were matched with "V2" and therefore "V20" was excluded.